### PR TITLE
Removed unnecessary check

### DIFF
--- a/truffleWorkspace/contracts/set_int.sol
+++ b/truffleWorkspace/contracts/set_int.sol
@@ -4,12 +4,10 @@ contract set_int {
     int256 public public_int;
     address owner;
     function set_int() public {
-        if (owner == address(0)){
-            owner = msg.sender;
-        }
+        owner = msg.sender;
         public_int = 42;
-    }  
+    }
     function set_int_data(int256 tmpNum) public {
         public_int = tmpNum;
-    } 
+    }
 }


### PR DESCRIPTION
set_int is a constructor so the check is not needed  - only the owner can run this code.

(sorry for the CRLF mess - I couldn't get around it)